### PR TITLE
[fix] theme : propagate theme from FluteKeyboard to TextKey

### DIFF
--- a/lib/src/alphanumeric_keyboard.dart
+++ b/lib/src/alphanumeric_keyboard.dart
@@ -18,7 +18,6 @@ class AlphanumericKeyboard extends BaseKeyboard {
   final Layout layout;
   late final FluteKeyboardTheme theme;
 
-
   AlphanumericKeyboard({
     super.key,
     required super.textController,
@@ -29,8 +28,7 @@ class AlphanumericKeyboard extends BaseKeyboard {
     required this.shiftActiveIcon,
     required this.layout,
     FluteKeyboardTheme? theme,
-  })
-  {
+  }) {
     this.theme = theme ?? FluteKeyboardTheme();
   }
 

--- a/lib/src/numeric_keyboard.dart
+++ b/lib/src/numeric_keyboard.dart
@@ -19,8 +19,7 @@ class NumericKeyboard extends BaseKeyboard {
     required super.returnIcon,
     required super.onReturn,
     FluteKeyboardTheme? theme,
-  }) 
-  {
+  }) {
     this.theme = theme ?? FluteKeyboardTheme();
   }
 

--- a/lib/src/text_key.dart
+++ b/lib/src/text_key.dart
@@ -18,8 +18,7 @@ class TextKey extends StatefulWidget {
     this.alternatives = const [],
     FluteKeyboardTheme? theme,
     super.key,
-  })
-  {
+  }) {
     this.theme = theme ?? FluteKeyboardTheme();
   }
 
@@ -37,7 +36,6 @@ class _LongPressKeyState extends State<TextKey> {
   Offset _popupPosition = Offset.zero;
 
   void _showOverlay(BuildContext context) {
-
     final RenderBox box =
         _keyGlobal.currentContext!.findRenderObject() as RenderBox;
     final Offset buttonPosition = box.localToGlobal(Offset.zero);


### PR DESCRIPTION
Before this PR, themes were not properly propagated ; this resulted in properties of TextStyle such as the font weight to not be effectively applied in the keyboard's text keys.

This PR:
* adds a nullable `theme` member to the classes `TextKey`, `AlphanumericKeyboard` and `NumericKeyboard` 
* uses that `theme` member in proper places instead of using a local instance of `FluteKeyboardTheme`