### PR TITLE
Show secondary value of keys

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -71,7 +71,7 @@ class _MyHomePageState extends State<MyHomePage> {
     );
     theme.btnSecondaryTextStyle = const TextStyle(
       color: Colors.grey,
-      fontSize: 16,
+      fontSize: 24,
     );
 
     return Scaffold(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -69,6 +69,10 @@ class _MyHomePageState extends State<MyHomePage> {
       color: Colors.black,
       fontSize: 28,
     );
+    theme.btnSecondaryTextStyle = const TextStyle(
+      color: Colors.grey,
+      fontSize: 16,
+    );
 
     return Scaffold(
       appBar: AppBar(
@@ -138,6 +142,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 shiftIcon: 'assets/shift.png',
                 shiftActiveIcon: 'assets/shift_active.png',
                 hideSpaceText: true,
+                showSecondaryValues: true,
                 onReturn: () {
                   // ignore: avoid_print
                   print(_textController.text);

--- a/lib/flutekeyboard.dart
+++ b/lib/flutekeyboard.dart
@@ -23,6 +23,7 @@ class FluteKeyboard extends StatefulWidget {
   final String shiftActiveIcon;
   final String backspaceIcon;
   final bool hideSpaceText;
+  final bool showSecondaryValues;
   final Layout alphanumericLayout;
   final Layout numericLayout;
 
@@ -46,6 +47,7 @@ class FluteKeyboard extends StatefulWidget {
     this.numericLayout = NumericLayout.layout,
     this.returnIcon = '',
     this.hideSpaceText = false,
+    this.showSecondaryValues = false,
   }) {
     this.theme = theme ?? FluteKeyboardTheme();
   }
@@ -72,6 +74,7 @@ class _FluteKeyboardState extends State<FluteKeyboard> {
       shiftActiveIcon: widget.shiftActiveIcon,
       backspaceIcon: widget.backspaceIcon,
       hideSpaceText: widget.hideSpaceText,
+      showSecondaryValues: widget.showSecondaryValues,
       layout: widget.alphanumericLayout,
       returnIcon: widget.returnIcon,
       onReturn: widget.onReturn,

--- a/lib/flutekeyboard_theme.dart
+++ b/lib/flutekeyboard_theme.dart
@@ -13,4 +13,5 @@ class FluteKeyboardTheme {
   Color btnSpecialBackgroundColor = Colors.transparent;
   TextStyle btnTextStyle = const TextStyle(color: Colors.white);
   Color btnReturnColor = Colors.transparent;
+  TextStyle btnSecondaryTextStyle = const TextStyle(color: Colors.grey);
 }

--- a/lib/src/alphanumeric_keyboard.dart
+++ b/lib/src/alphanumeric_keyboard.dart
@@ -14,6 +14,7 @@ class AlphanumericKeyboard extends BaseKeyboard {
   final String shiftIcon;
   final String shiftActiveIcon;
   final bool hideSpaceText;
+  final bool showSecondaryValues;
   final Layout layout;
   late final FluteKeyboardTheme theme;
 
@@ -28,6 +29,7 @@ class AlphanumericKeyboard extends BaseKeyboard {
     required this.layout,
     FluteKeyboardTheme? theme,
     this.hideSpaceText = false,
+    this.showSecondaryValues = false,
   }) {
     this.theme = theme ?? FluteKeyboardTheme();
   }
@@ -132,6 +134,7 @@ class _AlphanumericKeyboardState extends State<AlphanumericKeyboard> {
         text: mainChar,
         alternatives: alternatives,
         isShifted: _shiftActive,
+        showSecondaryValues: widget.showSecondaryValues,
         textController: widget.textController,
         theme: widget.theme,
       ),

--- a/lib/src/special_key.dart
+++ b/lib/src/special_key.dart
@@ -53,9 +53,11 @@ class _SpecialKeyState extends State<SpecialKey> {
         minimumSize: Size.zero,
       ),
       child: Center(
-        child: Text(
-          widget.text,
-          style: theme.btnTextStyle,
+        child: FittedBox(
+          child: Text(
+            widget.text,
+            style: theme.btnTextStyle,
+          ),
         ),
       ),
     );

--- a/lib/src/special_key.dart
+++ b/lib/src/special_key.dart
@@ -54,6 +54,7 @@ class _SpecialKeyState extends State<SpecialKey> {
       ),
       child: Center(
         child: FittedBox(
+          fit: BoxFit.scaleDown,
           child: Text(
             widget.text,
             style: theme.btnTextStyle,

--- a/lib/src/text_key.dart
+++ b/lib/src/text_key.dart
@@ -192,9 +192,7 @@ class _LongPressKeyState extends State<TextKey> {
             padding: EdgeInsets.zero,
             minimumSize: Size.zero,
           ),
-          child: Center(
-            child: FittedBox(child: _buildKeyContent(theme)),
-          ),
+          child: _buildKeyContent(theme),
         ),
       ),
     );
@@ -204,24 +202,38 @@ class _LongPressKeyState extends State<TextKey> {
       widget.isShifted ? value.toUpperCase() : value.toLowerCase();
 
   Widget _buildKeyContent(FluteKeyboardTheme theme) {
-    if (!widget.showSecondaryValues) {
-      return Text(
-        _applyCase(widget.text),
-        style: theme.btnTextStyle,
-      );
+    final primaryText = Center(
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Text(
+          _applyCase(widget.text),
+          style: theme.btnTextStyle,
+        ),
+      ),
+    );
+
+    if (!widget.showSecondaryValues || widget.alternatives.isEmpty) {
+      return primaryText;
     }
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      mainAxisAlignment: MainAxisAlignment.center,
+    return Stack(
+      fit: StackFit.expand,
       children: [
-        Text(
-          _applyCase(widget.alternatives.firstOrNull ?? ' '),
-          style: theme.btnSecondaryTextStyle.copyWith(height: 1),
-        ),
-        Text(
-          _applyCase(widget.text),
-          style: theme.btnTextStyle.copyWith(height: 1),
+        primaryText,
+        Align(
+          alignment: Alignment.topRight,
+          child: FractionallySizedBox(
+            widthFactor: 0.45,
+            heightFactor: 0.5,
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                _applyCase(widget.alternatives.first),
+                style: theme.btnSecondaryTextStyle,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
         ),
       ],
     );

--- a/lib/src/text_key.dart
+++ b/lib/src/text_key.dart
@@ -9,6 +9,7 @@ class TextKey extends StatefulWidget {
   final String text;
   final List<String> alternatives;
   final bool isShifted;
+  final bool showSecondaryValues;
   final TextEditingController textController;
   late final FluteKeyboardTheme theme;
 
@@ -17,6 +18,7 @@ class TextKey extends StatefulWidget {
     required this.isShifted,
     required this.textController,
     this.alternatives = const [],
+    this.showSecondaryValues = false,
     FluteKeyboardTheme? theme,
     super.key,
   }) {
@@ -82,7 +84,7 @@ class _LongPressKeyState extends State<TextKey> {
                   ),
                   alignment: Alignment.center,
                   child: Text(
-                    widget.isShifted ? char.toUpperCase() : char.toLowerCase(),
+                    _applyCase(char),
                     style: widget.theme.btnTextStyle,
                   ),
                 );
@@ -97,7 +99,7 @@ class _LongPressKeyState extends State<TextKey> {
   }
 
   void _insertText(String char) {
-    char = widget.isShifted ? char.toUpperCase() : char.toLowerCase();
+    char = _applyCase(char);
 
     // Cursor is at the end of the text.
     if (widget.textController.selection.start ==
@@ -191,15 +193,37 @@ class _LongPressKeyState extends State<TextKey> {
             minimumSize: Size.zero,
           ),
           child: Center(
-            child: Text(
-              widget.isShifted
-                  ? widget.text.toUpperCase()
-                  : widget.text.toLowerCase(),
-              style: theme.btnTextStyle,
-            ),
+            child: FittedBox(child: _buildKeyContent(theme)),
           ),
         ),
       ),
+    );
+  }
+
+  String _applyCase(String value) =>
+      widget.isShifted ? value.toUpperCase() : value.toLowerCase();
+
+  Widget _buildKeyContent(FluteKeyboardTheme theme) {
+    if (!widget.showSecondaryValues) {
+      return Text(
+        _applyCase(widget.text),
+        style: theme.btnTextStyle,
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          _applyCase(widget.alternatives.firstOrNull ?? ' '),
+          style: theme.btnSecondaryTextStyle.copyWith(height: 1),
+        ),
+        Text(
+          _applyCase(widget.text),
+          style: theme.btnTextStyle.copyWith(height: 1),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
This implements https://github.com/amarula/flutekeyboard/issues/6 .

* Add a flag `showSecondaryValues` that enables showing the first secondary key of any key, if any secondary key exists.
* The implementation is a simple column. Pinning the style's height factor to 1 keeps the font at a size that fits the case with `showSecondaryValues=false` nicely.
* Wrap key contents in a FittedBox to improve fitting of the text. This is the simplest option to make the secondary key properly fit in the available space. The other cases also benefit from this, so add it there, too.

Assisted-by: Copilot:opus-4.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configurable option to show secondary values on keyboard keys.
  * Added a theme customization option for secondary button text styling.
  * Improved key rendering to display a secondary label alongside the primary key value when enabled.  
* **Bug Fixes**
  * Improved special-key label rendering to better fit within the available button space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->